### PR TITLE
Delivery of the dmclock delta, rho and phase parameter + Enabling the client tracker

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -511,6 +511,8 @@ set(libcommon_files
   common/Cycles.cc
   common/scrub_types.cc
   common/bit_str.cc
+  dmclock/src/dmclock_util.cc
+  dmclock/support/src/run_every.cc
   osdc/Striper.cc
   osdc/Objecter.cc
   common/Graylog.cc

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -488,7 +488,8 @@ int main(int argc, const char **argv)
     CEPH_FEATURE_NOSRCADDR |
     CEPH_FEATURE_PGID64 |
     CEPH_FEATURE_MSG_AUTH |
-    CEPH_FEATURE_OSD_ERASURE_CODES;
+    CEPH_FEATURE_OSD_ERASURE_CODES |
+    CEPH_FEATURE_QOS_DMC;
 
   // All feature bits 0 - 34 should be present from dumpling v0.67 forward
   uint64_t osd_required =

--- a/src/common/mClockCommon.h
+++ b/src/common/mClockCommon.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SK Telecom
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "dmclock/src/dmclock_recs.h"
+
+// the following is done to unclobber _ASSERT_H so it returns to the
+// way ceph likes it
+#include "include/assert.h"
+
+
+namespace ceph {
+  namespace dmc = crimson::dmclock;
+}

--- a/src/common/mClockCommon.h
+++ b/src/common/mClockCommon.h
@@ -24,3 +24,17 @@
 namespace ceph {
   namespace dmc = crimson::dmclock;
 }
+
+WRITE_RAW_ENCODER(dmc::ReqParams)
+
+inline void encode(const dmc::PhaseType &phase, bufferlist& bl,
+                   uint64_t features=0)
+{
+  ::encode(static_cast<uint8_t>(phase), bl);
+}
+inline void decode(dmc::PhaseType &phase, bufferlist::iterator& p)
+{
+  uint8_t int_phase;
+  ::decode((uint8_t&)int_phase, p);
+  phase = static_cast<dmc::PhaseType>(int_phase);
+}

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -34,7 +34,7 @@ namespace ceph {
 
   namespace dmc = crimson::dmclock;
 
-  template <typename T, typename K>
+  template <typename T, typename K, typename ReqPm = dmc::ReqParams, typename RespPm = dmc::PhaseType>
   class mClockQueue : public OpQueue <T, K> {
 
     using priority_t = unsigned;
@@ -301,6 +301,12 @@ namespace ceph {
     void enqueue(K cl, unsigned priority, unsigned cost, T item) override final {
       // priority is ignored
       queue.add_request(item, cl, cost);
+    }
+
+    void _enqueue(K cl, unsigned priority, unsigned cost, T item,
+		  const ReqPm& req_params) {
+      // priority is ignored
+      queue.add_request(item, cl, req_params, cost);
     }
 
     void enqueue_front(K cl,

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -39,6 +39,7 @@ namespace ceph {
 
     using priority_t = unsigned;
     using cost_t = unsigned;
+    using Retn = std::pair<T, RespPm>;
 
     typedef std::list<std::pair<cost_t, T> > ListPairs;
 
@@ -342,6 +343,32 @@ namespace ceph {
       assert(pr.is_retn());
       auto& retn = pr.get_retn();
       return *(retn.request);
+    }
+
+    Retn _dequeue() {
+      assert(!empty());
+      RespPm resp_params = RespPm();
+
+      if (!(high_queue.empty())) {
+	T ret = high_queue.rbegin()->second.front().second;
+	high_queue.rbegin()->second.pop_front();
+	if (high_queue.rbegin()->second.empty()) {
+	  high_queue.erase(high_queue.rbegin()->first);
+	}
+	return std::make_pair(ret, resp_params);
+      }
+
+      if (!queue_front.empty()) {
+	T ret = queue_front.front().second;
+	queue_front.pop_front();
+	return std::make_pair(ret, resp_params);
+      }
+
+      auto pr = queue.pull_request();
+      assert(pr.is_retn());
+      auto& retn = pr.get_retn();
+      resp_params = retn.phase;
+      return std::make_pair(*(retn.request), resp_params);
     }
 
     void dump(ceph::Formatter *f) const override final {

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -88,6 +88,7 @@
 #define CEPH_FEATURE_FS_CHANGE_ATTR          (1ULL<<59) /* change_attr */
 
 #define CEPH_FEATURE_MSG_ADDR2 (1ULL<<59)  /* ADDR2 feature */
+#define CEPH_FEATURE_QOS_DMC          (1ULL<<60) /* dmclock QoS */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -187,6 +188,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_FS_BTIME |			 \
 	 CEPH_FEATURE_FS_CHANGE_ATTR |			 \
 	 CEPH_FEATURE_MSG_ADDR2 | \
+	 CEPH_FEATURE_QOS_DMC |			 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -20,7 +20,7 @@
 #include "osd/osd_types.h"
 #include "include/ceph_features.h"
 #include <atomic>
-
+#include "common/mClockCommon.h"
 /*
  * OSD op
  *
@@ -65,6 +65,7 @@ private:
   uint64_t features;
 
   osd_reqid_t reqid; // reqid explicitly set by sender
+  dmc::ReqParams qos_params;
 
 public:
   friend class MOSDOpReply;
@@ -78,6 +79,7 @@ public:
   void set_reqid(const osd_reqid_t rid) {
     reqid = rid;
   }
+  void set_qos_params(const dmc::ReqParams& p) { qos_params = p; }
 
   // Fields decoded in partial decoding
   const pg_t& get_pg() const {
@@ -107,6 +109,10 @@ public:
                          reqid.inc,
 			 header.tid);
     }
+  }
+  const dmc::ReqParams& get_qos_params() const {
+    assert(!partial_decode_needed);
+    return qos_params;
   }
 
   // Fields decoded in final decoding

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -21,6 +21,7 @@
 #include "MOSDOp.h"
 #include "os/ObjectStore.h"
 #include "common/errno.h"
+#include "common/mClockCommon.h"
 
 /*
  * OSD op reply
@@ -32,7 +33,7 @@
 
 class MOSDOpReply : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 2;
 
   object_t oid;
@@ -47,6 +48,7 @@ class MOSDOpReply : public Message {
   int32_t retry_attempt;
   bool do_redirect;
   request_redirect_t redirect;
+  dmc::PhaseType qos_resp;
 
 public:
   const object_t& get_oid() const { return oid; }
@@ -93,6 +95,8 @@ public:
   void set_redirect(const request_redirect_t& redir) { redirect = redir; }
   const request_redirect_t& get_redirect() const { return redirect; }
   bool is_redirect_reply() const { return do_redirect; }
+  void set_qos_resp(const dmc::PhaseType qresp) { qos_resp = qresp; }
+  dmc::PhaseType get_qos_resp() const { return qos_resp; }
 
   void add_flags(int f) { flags |= f; }
 
@@ -128,10 +132,10 @@ public:
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION) {
     do_redirect = false;
   }
-  MOSDOpReply(MOSDOp *req, int r, epoch_t e, int acktype, bool ignore_out_data)
+  MOSDOpReply(MOSDOp *req, int r, epoch_t e, int acktype, bool ignore_out_data,
+              dmc::PhaseType qresp = dmc::PhaseType::reservation)
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION),
-      oid(req->oid), pgid(req->pgid), ops(req->ops) {
-
+      oid(req->oid), pgid(req->pgid), ops(req->ops), qos_resp(qresp) {
     set_tid(req->get_tid());
     result = r;
     flags =
@@ -202,6 +206,11 @@ public:
         if (do_redirect) {
           ::encode(redirect, payload);
         }
+        if ((features & CEPH_FEATURE_QOS_DMC) == 0) {
+          header.version = 7;
+        } else {
+          ::encode(qos_resp, payload);
+        }
       }
     }
   }
@@ -234,6 +243,7 @@ public:
       ::decode(do_redirect, p);
       if (do_redirect)
 	::decode(redirect, p);
+      ::decode(qos_resp, p);
     } else if (header.version < 2) {
       ceph_osd_reply_head head;
       ::decode(head, p);
@@ -292,6 +302,10 @@ public:
         if (do_redirect) {
 	  ::decode(redirect, p);
         }
+      }
+
+      if (header.version >=8 ) {
+        ::decode(qos_resp, p);
       }
     }
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1367,7 +1367,7 @@ void OSDService::reply_op_error(OpRequestRef op, int err, eversion_t v,
   flags = m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK);
 
   MOSDOpReply *reply = new MOSDOpReply(m, err, osdmap->get_epoch(), flags,
-				       true);
+				       true, op->qos_resp);
   reply->set_reply_versions(v, uv);
   m->get_connection()->send_message(reply);
 }
@@ -8850,6 +8850,9 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
     }
   }
   pair<PGRef, PGQueueable> item = sdata->pqueue->dequeue();
+  if (boost::optional<OpRequestRef> _op = item.second.maybe_get_op()) {
+    (*_op)->qos_resp = item.second.get_qos_resp();
+  }
   sdata->pg_for_processing[&*(item.first)].push_back(item.second);
   sdata->sdata_op_ordering_lock.Unlock();
   ThreadPool::TPHandle tp_handle(osd->cct, hb, timeout_interval,

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -28,7 +28,7 @@ OpRequest::OpRequest(Message *req, OpTracker *tracker) :
   rmw_flags(0), request(req),
   hit_flag_points(0), latest_flag_point(0),
   send_map_update(false), sent_epoch(0),
-  hitset_inserted(false) {
+  hitset_inserted(false), qos_resp(dmc::PhaseType::reservation) {
   if (req->get_priority() < tracker->cct->_conf->osd_client_op_priority) {
     // don't warn as quickly for low priority ops
     warn_interval_multiplier = tracker->cct->_conf->osd_recovery_op_warn_multiple;

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -23,6 +23,7 @@
 #include "msg/Message.h"
 #include "include/memory.h"
 #include "common/TrackedOp.h"
+#include "common/mClockCommon.h"
 
 /**
  * osd request identifier
@@ -136,6 +137,7 @@ public:
   bool send_map_update;
   epoch_t sent_epoch;
   bool hitset_inserted;
+  dmc::PhaseType qos_resp;
   Message *get_req() const { return request; }
   bool been_queued_for_pg() { return hit_flag_points & flag_queued_for_pg; }
   bool been_reached_pg() { return hit_flag_points & flag_reached_pg; }

--- a/src/osd/PGQueueable.h
+++ b/src/osd/PGQueueable.h
@@ -69,6 +69,7 @@ class PGQueueable {
   utime_t start_time;
   entity_inst_t owner;
   dmc::ReqParams qos_params;
+  dmc::PhaseType qos_resp;
 
   struct RunVis : public boost::static_visitor<> {
     OSD *osd;
@@ -98,7 +99,8 @@ public:
     : qvariant(op), cost(op->get_req()->get_cost()),
       priority(op->get_req()->get_priority()),
       start_time(op->get_req()->get_recv_stamp()),
-      owner(op->get_req()->get_source_inst())
+      owner(op->get_req()->get_source_inst()),
+      qos_resp(dmc::PhaseType::reservation)
   {
     if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
       MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
@@ -109,17 +111,17 @@ public:
     const PGSnapTrim &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
   PGQueueable(
     const PGScrub &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
   PGQueueable(
     const PGRecovery &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
 
   friend std::ostream& operator<<(std::ostream&, const PGQueueable&);
 
@@ -141,6 +143,8 @@ public:
   entity_inst_t get_owner() const { return owner; }
   const QVariant& get_variant() const { return qvariant; }
   dmc::ReqParams get_qos_params() const { return qos_params; }
+  dmc::PhaseType get_qos_resp() const { return qos_resp; }
+  void set_qos_resp(dmc::PhaseType qresp) { qos_resp = qresp; }
 }; // class PGQueueable
 
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1485,7 +1485,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
   // reply
   MOSDOpReply *reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(),
 				       CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK,
-				       false);
+				       false, op->qos_resp);
   reply->claim_op_out_data(ops);
   reply->set_result(result);
   reply->set_reply_versions(info.last_update, info.last_user_version);
@@ -2337,7 +2337,7 @@ void PrimaryLogPG::record_write_error(OpRequestRef op, const hobject_t &soid,
       MOSDOpReply *reply = orig_reply.detach();
       if (reply == nullptr) {
 	reply = new MOSDOpReply(m, r, pg->get_osdmap()->get_epoch(),
-				flags, true);
+				flags, true, op->qos_resp);
       }
       ldpp_dout(pg, 10) << " sending commit on " << *m << " " << reply << dendl;
       pg->osd->send_message_osd_client(reply, m->get_connection());
@@ -2627,8 +2627,8 @@ void PrimaryLogPG::do_cache_redirect(OpRequestRef op)
 {
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
   int flags = m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK);
-  MOSDOpReply *reply = new MOSDOpReply(m, -ENOENT,
-				       get_osdmap()->get_epoch(), flags, false);
+  MOSDOpReply *reply = new MOSDOpReply(m, -ENOENT, get_osdmap()->get_epoch(),
+                                       flags, false, op->qos_resp);
   request_redirect_t redir(m->get_object_locator(), pool.info.tier_of);
   reply->set_redirect(redir);
   dout(10) << "sending redirect to pool " << pool.info.tier_of << " for op "
@@ -2767,7 +2767,8 @@ void PrimaryLogPG::finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r)
 
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
   OpContext *ctx = new OpContext(op, m->get_reqid(), prdop->ops, this);
-  ctx->reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false);
+  ctx->reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false,
+                               op->qos_resp);
   ctx->user_at_version = prdop->user_version;
   ctx->data_off = prdop->data_offset;
   ctx->ignore_log_op_stats = true;
@@ -2940,7 +2941,8 @@ void PrimaryLogPG::finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r)
     if (reply)
       pwop->ctx->reply = NULL;
     else {
-      reply = new MOSDOpReply(m, r, get_osdmap()->get_epoch(), 0, true);
+      reply = new MOSDOpReply(m, r, get_osdmap()->get_epoch(), 0, true,
+	                      pwop->op->qos_resp);
       reply->set_reply_versions(eversion_t(), pwop->user_version);
     }
     reply->add_flags(CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK);
@@ -2954,7 +2956,8 @@ void PrimaryLogPG::finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r)
     if (reply)
       pwop->ctx->reply = NULL;
     else {
-      reply = new MOSDOpReply(m, r, get_osdmap()->get_epoch(), 0, true);
+      reply = new MOSDOpReply(m, r, get_osdmap()->get_epoch(), 0, true,
+	                      pwop->op->qos_resp);
       reply->set_reply_versions(eversion_t(), pwop->user_version);
     }
     reply->add_flags(CEPH_OSD_FLAG_ACK);
@@ -3162,7 +3165,7 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
   bool successful_write = !ctx->op_t->empty() && op->may_write() && result >= 0;
   // prepare the reply
   ctx->reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0,
-			       successful_write);
+			       successful_write, op->qos_resp);
 
   // Write operations aren't allowed to return a data payload because
   // we can't do so reliably. If the client has to resend the request
@@ -3256,7 +3259,8 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
 	if (reply)
 	  ctx->reply = NULL;
 	else {
-	  reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, true);
+	  reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, true,
+	                          ctx->op->qos_resp);
 	  reply->set_reply_versions(ctx->at_version,
 				    ctx->user_at_version);
 	}
@@ -7231,7 +7235,8 @@ void PrimaryLogPG::fill_in_copy_get_noent(OpRequestRef& op, hobject_t oid,
     ::encode(reply_obj, osd_op.outdata, features);
   }
   osd_op.rval = -ENOENT;
-  MOSDOpReply *reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false);
+  MOSDOpReply *reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false,
+                                       op->qos_resp);
   reply->claim_op_out_data(m->ops);
   reply->set_result(-ENOENT);
   reply->add_flags(CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK);

--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -147,7 +147,8 @@ namespace ceph {
 					 unsigned priority,
 					 unsigned cost,
 					 Request item) {
-    queue.enqueue(get_inner_client(cl, item), priority, cost, item);
+    queue._enqueue(get_inner_client(cl, item), priority, cost, item,
+		   item.second.get_qos_params());
   }
 
   // Enqueue the op in the front of the regular queue

--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -161,7 +161,9 @@ namespace ceph {
 
   // Return an op to be dispatch
   inline Request mClockClientQueue::dequeue() {
-    return queue.dequeue();
+    std::pair<Request, dmc::PhaseType> retn = queue._dequeue();
+    retn.first.second.set_qos_resp(retn.second);
+    return retn.first;
   }
 
   std::ostream& operator<<(std::ostream& out, const Request& req) {

--- a/src/osdc/CMakeLists.txt
+++ b/src/osdc/CMakeLists.txt
@@ -6,3 +6,4 @@ set(osdc_rbd_files
   Striper.cc)
 add_library(osdc_rbd_objs OBJECT ${osdc_rbd_files})
 add_library(osdc STATIC ${osdc_files} $<TARGET_OBJECTS:osdc_rbd_objs>)
+target_link_libraries(osdc dmclock)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3344,6 +3344,11 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   /* get it before we call _finish_op() */
   auto completion_lock = s->get_lock(op->target.base_oid);
 
+  unsigned prev_seed = ceph_stable_mod(op->target.pgid.ps(),
+                                       op->target.pg_num,
+                                       op->target.pg_num_mask);
+  uint32_t shard_index = prev_seed % num_shards;
+  qos_trk->track_resp(OsdID(op->target.osd, shard_index), m->get_qos_resp());
   ldout(cct, 15) << "handle_osd_op_reply completed tid " << tid << dendl;
   _finish_op(op, 0);
 


### PR DESCRIPTION
**1. The operations related with dmclock delta, rho and phase parameter**
To support per-client dmclock OP queue in distributed environment, each operation between Ceph OSD and Client must include distributed environment factor such as delta, rho. Currently, the Ceph Operations are classified into OpRequest and PGxxx (Background Operations(snaptrim, recov, scrub)). Also OpRequest can be further subdivided into type of MSGs.
Thus we included environment factor only in CEPH_MSG_OSD_OP, CEPH_MSG_OSD_OPREPLY and handled them by using the client service tracker.
(Note that, now MSG_OSD_REPOP, MSG_OSD_REPOPREPLY are handled by enqueue_strict queue due to its high priority than op_prio_cutoff).

**2. The location of client service tracker**
As discussed previously, we put the client service tracker class into Objecter class to minimize current code change. But, depending on the abstraction concept, it can be placed elsewhere such as IoCtxImpl class.